### PR TITLE
Initial support for causal clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ The Neo4j controller module comprises a set of scripts for downloading, starting
 These scripts should work for any 3.0+ server version and can pull builds from TeamCity if credentials are supplied.
 In this case, the download is attempted from TeamCity first and the regular distribution server is used as a fallback.
 
+Module also contains `neoctrl-cluster` command that gives ability to install, start and stop Neo4j Causal clusters.
+It is supported for 3.1+ Neo4j versions only.
+
 ### `neoctrl-download` <a name="neo4j-controller/download">§</a>
 ```
 usage: neoctrl-download [-h] [-e] [-v] version [path]
@@ -322,6 +325,74 @@ positional arguments:
 optional arguments:
   -h, --help     show this help message and exit
   -v, --verbose  show more detailed output
+
+Report bugs to drivers@neo4j.com
+```
+
+### <a name="neo4j-controller/cluster"></a>`neoctrl-cluster install` 
+```
+usage: neoctrl-cluster install [-h] [-v] [-c CORE_COUNT]
+                               [-r READ_REPLICA_COUNT]
+                               version [path]
+
+Download, extract and configure causal cluster.
+
+example:
+  neoctrl-cluster install [-v] 3.1.0 3 $HOME/cluster/
+
+positional arguments:
+  version               Neo4j server version
+  path                  download destination path (default: .)
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --verbose         show more detailed output
+  -c CORE_COUNT, --cores CORE_COUNT
+                        Number of core members in the cluster (default 3)
+  -r READ_REPLICA_COUNT, --read-replicas READ_REPLICA_COUNT
+                        Number of read replicas in the cluster (default 0)
+
+See neoctrl-download for details of supported environment variables.
+
+Report bugs to drivers@neo4j.com
+```
+
+### <a name="neo4j-controller/cluster"></a>`neoctrl-cluster start` 
+```
+usage: neoctrl-cluster start [-h] [path]
+
+Start the causal cluster located at the given path.
+
+example:
+  neoctrl-cluster start $HOME/cluster/
+
+positional arguments:
+  path        causal cluster location path (default: .)
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+See neoctrl-download for details of supported environment variables.
+
+Report bugs to drivers@neo4j.com
+```
+
+### <a name="neo4j-controller/cluster"></a>`neoctrl-cluster stop` 
+```
+usage: neoctrl-cluster stop [-h] [path]
+
+Stop the causal cluster located at the given path.
+
+example:
+  neoctrl-cluster stop $HOME/cluster/
+
+positional arguments:
+  path        causal cluster location path (default: .)
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+See neoctrl-download for details of supported environment variables.
 
 Report bugs to drivers@neo4j.com
 ```

--- a/boltkit/config.py
+++ b/boltkit/config.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Copyright (c) 2002-2016 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from os.path import join as path_join
+
+try:
+    from urllib.request import urlopen, Request, HTTPError
+    from urllib.parse import urlparse
+except ImportError:
+    from urllib2 import urlopen, Request, HTTPError
+    from urlparse import urlparse
+
+CONF_DIR = "conf"
+CONF_FILE = "neo4j.conf"
+
+HTTP_URI_SETTING = "dbms.connector.http.listen_address"
+BOLT_URI_SETTING = "dbms.connector.bolt.listen_address"
+
+
+def update(path, properties):
+    config_file_path = _config_file_path(path)
+
+    with open(config_file_path, "r") as f_in:
+        lines = f_in.readlines()
+    with open(config_file_path, "w") as f_out:
+        for line in lines:
+            for key, value in properties.items():
+                if line.startswith(key + "=") or \
+                        (line.startswith("#") and line[1:].lstrip().startswith(key + "=")):
+                    f_out.write("%s=%s\n" % (key, value))
+                    break
+            else:
+                f_out.write(line)
+
+
+def extract_http_and_bolt_uris(path):
+    config_file_path = _config_file_path(path)
+
+    with open(config_file_path, "r") as f_in:
+        lines = f_in.readlines()
+
+    http_uri = None
+    bolt_uri = None
+
+    for line in lines:
+        if HTTP_URI_SETTING in line:
+            if http_uri is not None:
+                raise RuntimeError("Duplicated http uri configs found in %s" % config_file_path)
+
+            http_uri = _parse_uri("http", line)
+
+        if BOLT_URI_SETTING in line:
+            if bolt_uri is not None:
+                raise RuntimeError("Duplicated bolt uri configs found in %s" % config_file_path)
+
+            bolt_uri = _parse_uri("bolt", line)
+
+    return http_uri, bolt_uri
+
+
+def for_core(expected_core_cluster_size, initial_discovery_members, discovery_listen_address,
+             transaction_listen_address, raft_listen_address, bolt_listen_address, http_listen_address,
+             https_listen_address):
+    config = {
+        "dbms.mode": "CORE",
+        "causal_clustering.expected_core_cluster_size": expected_core_cluster_size,
+        "causal_clustering.initial_discovery_members": initial_discovery_members,
+        "causal_clustering.discovery_listen_address": discovery_listen_address,
+        "causal_clustering.transaction_listen_address": transaction_listen_address,
+        "causal_clustering.raft_listen_address": raft_listen_address,
+        "dbms.connector.bolt.listen_address": bolt_listen_address,
+        "dbms.connector.http.listen_address": http_listen_address,
+        "dbms.connector.https.listen_address": https_listen_address
+    }
+    config.update(_memory_config())
+    return config
+
+
+def for_read_replica(initial_discovery_members, bolt_listen_address, http_listen_address, https_listen_address):
+    config = {
+        "dbms.mode": "READ_REPLICA",
+        "causal_clustering.initial_discovery_members": initial_discovery_members,
+        "dbms.connector.bolt.listen_address": bolt_listen_address,
+        "dbms.connector.http.listen_address": http_listen_address,
+        "dbms.connector.https.listen_address": https_listen_address
+    }
+    config.update(_memory_config())
+    return config
+
+
+def _memory_config():
+    return {
+        "dbms.memory.pagecache.size": "50m",
+        "dbms.memory.heap.initial_size": "250m",
+        "dbms.memory.heap.max_size": "250m"
+    }
+
+
+def _parse_uri(scheme, config_entry):
+    uri = config_entry.partition("=")[-1].strip()
+
+    if uri.startswith(":"):
+        uri = scheme + "://localhost" + uri
+
+    if not uri.startswith(scheme + "://"):
+        uri = scheme + "://" + uri
+
+    parsed_uri = urlparse(uri)
+
+    if not parsed_uri.scheme or not parsed_uri.hostname or not parsed_uri.port:
+        raise RuntimeError("Cannot parse uri from config '%s'" % uri)
+
+    return parsed_uri
+
+
+def _config_file_path(root):
+    return path_join(root, CONF_DIR, CONF_FILE)

--- a/boltkit/controller.py
+++ b/boltkit/controller.py
@@ -625,6 +625,9 @@ def _cluster_install(parsed):
             core_member_home = _create_controller().extract(package, core_member_path)
             _create_controller(core_member_home).configure(
                 {
+                    "dbms.memory.pagecache.size": "100m",
+                    "dbms.memory.heap.initial_size": "300m",
+                    "dbms.memory.heap.max_size": "300m",
                     "dbms.mode": "CORE",
                     "causal_clustering.expected_core_cluster_size": core_members_count,
                     "causal_clustering.initial_discovery_members": ",".join(discovery_listen_addresses),
@@ -715,6 +718,5 @@ def _extract_http_uri_from_config(config_file_path):
 # todo:
 #  - add read replicas to cluster create
 #  - add read replicas dynamically
-#  - update page cache memory and Xmx
 #  - provide custom props for cluster setup
 #  - unpack archives to 'core-XXX' dirs directly

--- a/boltkit/controller.py
+++ b/boltkit/controller.py
@@ -533,45 +533,50 @@ def install():
 
 
 def cluster():
+    see_download_command = ("See neoctrl-download for details of supported environment variables.\r\n"
+                            "\r\n"
+                            "Report bugs to drivers@neo4j.com")
+
     parser = ArgumentParser(
         description="Operate Neo4j causal cluster.\r\n"
                     "\r\n"
                     "example:\r\n"
                     "  neoctrl-cluster start 3.1.0-M09 $HOME/servers/",
-        epilog="See neoctrl-download for details of supported environment variables.\r\n"
-               "\r\n"
-               "Report bugs to drivers@neo4j.com",
+        epilog=see_download_command,
         formatter_class=RawDescriptionHelpFormatter)
 
     subparsers = parser.add_subparsers(help="available sub-commands", dest="command")
 
-    parser_install = subparsers.add_parser("install",
+    parser_install = subparsers.add_parser("install", epilog=see_download_command,
                                            description="Download, extract and configure causal cluster.\r\n"
                                                        "\r\n"
                                                        "example:\r\n"
-                                                       "  neoctrl-cluster install [-v] 3.1.0 3 $HOME/cluster/")
+                                                       "  neoctrl-cluster install [-v] 3.1.0 3 $HOME/cluster/",
+                                           formatter_class=RawDescriptionHelpFormatter)
 
     parser_install.add_argument("-v", "--verbose", action="store_true", help="show more detailed output")
     parser_install.add_argument("version", help="Neo4j server version")
     parser_install.add_argument("-c", "--cores", default="3", dest="core_count",
-                                help="Number of core members in the Neo4j cluster (default 3)")
+                                help="Number of core members in the cluster (default 3)")
     parser_install.add_argument("-r", "--read-replicas", default="0", dest="read_replica_count",
-                                help="Number of read replicas in the Neo4j cluster (default 0)")
+                                help="Number of read replicas in the cluster (default 0)")
     parser_install.add_argument("path", nargs="?", default=".", help="download destination path (default: .)")
 
-    parser_start = subparsers.add_parser("start",
+    parser_start = subparsers.add_parser("start", epilog=see_download_command,
                                          description="Start the causal cluster located at the given path.\r\n"
                                                      "\r\n"
                                                      "example:\r\n"
-                                                     "  neoctrl-cluster start $HOME/cluster/")
+                                                     "  neoctrl-cluster start $HOME/cluster/",
+                                         formatter_class=RawDescriptionHelpFormatter)
 
     parser_start.add_argument("path", nargs="?", default=".", help="causal cluster location path (default: .)")
 
-    parser_stop = subparsers.add_parser("stop",
+    parser_stop = subparsers.add_parser("stop", epilog=see_download_command,
                                         description="Stop the causal cluster located at the given path.\r\n"
                                                     "\r\n"
                                                     "example:\r\n"
-                                                    "  neoctrl-cluster stop $HOME/cluster/")
+                                                    "  neoctrl-cluster stop $HOME/cluster/",
+                                        formatter_class=RawDescriptionHelpFormatter)
 
     parser_stop.add_argument("path", nargs="?", default=".", help="causal cluster location path (default: .)")
 

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ package_metadata = {
             "boltstub = boltkit.server:stub",
             "neoctrl-download = boltkit.controller:download",
             "neoctrl-install = boltkit.controller:install",
+            "neoctrl-cluster = boltkit.controller:cluster",
             "neoctrl-start = boltkit.controller:start",
             "neoctrl-stop = boltkit.controller:stop",
             "neoctrl-create-user = boltkit.controller:create_user",


### PR DESCRIPTION
Available commands:

Initial cluster installation (download package, unpack and configure instances):
```
neoctrl-cluster install --cores 3 --read-replicas 5 3.1.0-M13-beta3 /tmp/cluster
neoctrl-cluster install -c 3 --r 5 3.1.0-M13-beta3 /tmp/cluster
```

Cluster start:
```
neoctrl-cluster start /tmp/cluster
```

Cluster stop:
```
neoctrl-cluster stop /tmp/cluster
```

Re-configuration, start and stop of individual instances could be done using existing commands: `neoctrl-configure`, `neoctrl-start` and `neoctrl-stop`.

Missing:
 * hard kill of instances (will be added to `neoctrl-stop` command)
 * dynamic addition of cluster instances