### PR TITLE
Make initial cluster port configurable

### DIFF
--- a/boltkit/controller.py
+++ b/boltkit/controller.py
@@ -24,6 +24,7 @@ import platform
 from argparse import ArgumentParser, RawDescriptionHelpFormatter, REMAINDER
 from base64 import b64encode
 from hashlib import sha256
+from itertools import count
 from os import getenv, makedirs, listdir
 from os.path import join as path_join, normpath, realpath, isdir, isfile, getsize
 from random import randint
@@ -396,9 +397,10 @@ class Cluster:
     def install(self, version, core_count, read_replica_count, initial_port, password, verbose=False):
         try:
             package = _create_controller().download("enterprise", version, self.path, verbose=verbose)
+            port_gen = count(initial_port)
 
-            initial_discovery_members, port = self._install_cores(self.path, package, core_count, initial_port)
-            self._install_read_replicas(self.path, package, initial_discovery_members, read_replica_count, port)
+            initial_discovery_members = self._install_cores(self.path, package, core_count, port_gen)
+            self._install_read_replicas(self.path, package, initial_discovery_members, read_replica_count, port_gen)
             self._set_initial_password(password)
 
             return realpath(self.path)
@@ -426,7 +428,7 @@ class Cluster:
         self._foreach_cluster_member(lambda path: self._cluster_member_set_initial_password(path, password))
 
     @classmethod
-    def _install_cores(cls, path, package, core_count, port):
+    def _install_cores(cls, path, package, core_count, port_generator):
         discovery_listen_addresses = []
         transaction_listen_addresses = []
         raft_listen_addresses = []
@@ -435,18 +437,12 @@ class Cluster:
         https_listen_addresses = []
 
         for core_idx in range(0, core_count):
-            discovery_listen_addresses.append(_localhost(port))
-            port += 1
-            transaction_listen_addresses.append(_localhost(port))
-            port += 1
-            raft_listen_addresses.append(_localhost(port))
-            port += 1
-            bolt_listen_addresses.append(_localhost(port))
-            port += 1
-            http_listen_addresses.append(_localhost(port))
-            port += 1
-            https_listen_addresses.append(_localhost(port))
-            port += 1
+            discovery_listen_addresses.append(_localhost(next(port_generator)))
+            transaction_listen_addresses.append(_localhost(next(port_generator)))
+            raft_listen_addresses.append(_localhost(next(port_generator)))
+            bolt_listen_addresses.append(_localhost(next(port_generator)))
+            http_listen_addresses.append(_localhost(next(port_generator)))
+            https_listen_addresses.append(_localhost(next(port_generator)))
 
         initial_discovery_members = ",".join(discovery_listen_addresses)
 
@@ -469,22 +465,19 @@ class Cluster:
 
             config.update(core_member_home, core_config)
 
-        return initial_discovery_members, port
+        return initial_discovery_members
 
     @classmethod
-    def _install_read_replicas(cls, path, package, initial_discovery_members, read_replica_count, port):
+    def _install_read_replicas(cls, path, package, initial_discovery_members, read_replica_count, port_generator):
         controller = _create_controller()
         for read_replica_idx in range(0, read_replica_count):
             read_replica_dir = READ_REPLICA_DIR_FORMAT % read_replica_idx
             read_replica_path = path_join(path, READ_REPLICAS_DIR, read_replica_dir)
             read_replica_home = controller.extract(package, read_replica_path)
 
-            bolt_listen_address = _localhost(port)
-            port += 1
-            http_listen_address = _localhost(port)
-            port += 1
-            https_listen_address = _localhost(port)
-            port += 1
+            bolt_listen_address = _localhost(next(port_generator))
+            http_listen_address = _localhost(next(port_generator))
+            https_listen_address = _localhost(next(port_generator))
 
             read_replica_config = config.for_read_replica(initial_discovery_members, bolt_listen_address,
                                                           http_listen_address, https_listen_address)
@@ -667,7 +660,7 @@ def cluster():
                                 help="Number of core members in the cluster (default 3)")
     parser_install.add_argument("-r", "--read-replicas", default="0", dest="read_replica_count",
                                 help="Number of read replicas in the cluster (default 0)")
-    parser_install.add_argument("-ip", "--initial-port", default=str(DEFAULT_INITIAL_PORT),
+    parser_install.add_argument("-i", "--initial-port", default=str(DEFAULT_INITIAL_PORT),
                                 dest="initial_port", help="Initial port number for all used ports on all cluster "
                                                           "members. Each next port will simply be an increment of "
                                                           "the previous one (default %d)" % DEFAULT_INITIAL_PORT)
@@ -715,14 +708,14 @@ def _execute_cluster_command(parsed):
     command = parsed.command
     cluster_ctrl = Cluster(parsed.path)
     if command == "install":
-        core_count = int(parsed.core_count)
-        read_replica_count = int(parsed.read_replica_count)
-        initial_port = int(parsed.initial_port)
+        core_count = _parse_int(parsed.core_count, "core count")
+        read_replica_count = _parse_int(parsed.read_replica_count, "read replica count")
+        initial_port = _parse_int(parsed.initial_port, "initial port")
         path = cluster_ctrl.install(parsed.version, core_count, read_replica_count, initial_port, parsed.password,
                                     parsed.verbose)
         print(path)
     elif command == "start":
-        startup_timeout = int(parsed.timeout)
+        startup_timeout = _parse_int(parsed.timeout, "timeout")
         cluster_info = cluster_ctrl.start(startup_timeout)
         print(cluster_info)
     elif command == "stop":
@@ -878,6 +871,13 @@ def test():
 
 def _create_controller(path=None):
     return WindowsController(path) if platform.system() == "Windows" else UnixController(path)
+
+
+def _parse_int(string_value, message):
+    try:
+        return int(string_value)
+    except ValueError:
+        raise RuntimeError("Int value expected for %s but received '%s'" % (message, string_value))
 
 
 def _localhost(port):


### PR DESCRIPTION
Previously all initial ports were hardcoded and not configurable. This commit makes `neoctrl-cluter install` command accept a single initial port. Every next port in the cluster is just an increment of the previous one.