### PR TITLE
Swallow socket shutdown/close errors

### DIFF
--- a/boltkit/server.py
+++ b/boltkit/server.py
@@ -224,8 +224,11 @@ class StubServer(Thread):
         peers, self.peers, self.running = list(self.peers.items()), {}, False
         for sock, peer in peers:
             log.info("~~ <CLOSE> \"%s\" %d", *peer.address)
-            sock.shutdown(SHUT_RDWR)
-            sock.close()
+            try:
+                sock.shutdown(SHUT_RDWR)
+                sock.close()
+            except socket_error:
+                pass
 
     def read(self, sock):
         try:
@@ -318,7 +321,7 @@ class StubServer(Thread):
     def send_bytes(self, sock, data):
         try:
             sock.sendall(data)
-        except socket_error as error:
+        except socket_error:
             log.error("S: <GONE>")
             exit(1)
         else:


### PR DESCRIPTION
Often when closing stub server exceptions like this were printed:

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "build/bdist.macosx-10.12-intel/egg/boltkit/server.py", line 216, in run
    self.read(sock)
  File "build/bdist.macosx-10.12-intel/egg/boltkit/server.py", line 235, in read
    self.handle_request(sock)
  File "build/bdist.macosx-10.12-intel/egg/boltkit/server.py", line 274, in handle_request
    self.stop()
  File "build/bdist.macosx-10.12-intel/egg/boltkit/server.py", line 227, in stop
    sock.shutdown(SHUT_RD)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
error: [Errno 57] Socket is not connected
```

This PR makes code ignore such exceptions because they are not that helpful.