### PR TITLE
Fix string handling on set-initial-password

### DIFF
--- a/boltkit/controller.py
+++ b/boltkit/controller.py
@@ -319,7 +319,7 @@ class Controller(object):
         if self._neo4j_admin_available():
             neo4j_admin_path = path_join(self.home, "bin", self._neo4j_admin_script_name())
             output = _invoke([neo4j_admin_path, "set-initial-password", password])
-            live_users_detected = "password was not set" in output.lower()
+            live_users_detected = b"password was not set" in output.lower()
         else:
             if self._auth_file_exists():
                 live_users_detected = True
@@ -333,7 +333,7 @@ class Controller(object):
         try:
             neo4j_admin_path = path_join(self.home, "bin", self._neo4j_admin_script_name())
             output = _invoke([neo4j_admin_path, "help"])
-            return "set-initial-password" in output
+            return b"set-initial-password" in output
         except CalledProcessError:
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ except ImportError:
 packages = find_packages(exclude=("test", "test.*"))
 package_metadata = {
     "name": "boltkit",
-    "version": "1.0.27",
+    "version": "1.0.28",
     "description": "Toolkit for Neo4j 3.0+ driver authors",
     "author": "Neo Technology",
     "author_email": "drivers@neo4j.com",


### PR DESCRIPTION
PR adds `b` prefix to a couple of strings to make boltkit to run on python3.